### PR TITLE
<chart/thanos/0.3.19> Store: Add support for StatefulSet

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.18
+version: 0.3.19
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -188,6 +188,9 @@ These values are just samples, for more fine-tuning please check the values.yaml
 |----|-----------|--------------|
 | store.enabled | Enable component | true |
 | store.replicaCount | Pod replica count | 1 |
+| store.statefulSet.enabled | Use StatefulSet instead of Deployment | false |
+| store.statefulSet.size | Size of the PVC | 10G |
+| store.statefulSet.storageClassName | StorageClassName for the PVC | default |
 | store.logLevel | Log level | info |
 | store.logFormat | Log format to use. Possible options: logfmt or json. | logfmt |
 | store.indexCacheSize | Maximum size of items held in the index cache. | 250MB |

--- a/thanos/templates/store-persistentvolumeclaim.yaml
+++ b/thanos/templates/store-persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.store.enabled .Values.store.persistentVolumeClaim }}
+{{- if (and .Values.store.enabled .Values.store.persistentVolumeClaim (not .Values.store.statefulSet.enabled))}}
 {{- $pvc := .Values.store.persistentVolumeClaim -}}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/thanos/templates/store.yaml
+++ b/thanos/templates/store.yaml
@@ -2,7 +2,7 @@
 {{ if .Values.store.enabled }}
 {{- range $index, $partion := .Values.store.timePartioning }}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ if $root.Values.store.statefulSet.enabled }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-{{ $index }}
   labels:
@@ -15,12 +15,16 @@ metadata:
     app.kubernetes.io/partition: "{{ $index }}"
 {{ with $root.Values.store.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end }}
   {{- with $root.Values.store.deploymentAnnotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations:{{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ $root.Values.store.replicaCount | default 1 }}
   {{- with  $root.Values.store.strategy }}
   strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if  $root.Values.store.statefulSet.enabled }}
+  serviceName: {{ include "thanos.name" $root }}
+  podManagementPolicy: Parallel
   {{- end }}
   selector:
     matchLabels:
@@ -96,7 +100,7 @@ spec:
         - name: config-volume
           mountPath: /etc/config
           readOnly: true
-        - name: data
+        - name: thanos-store-data
           mountPath: /var/thanos/store
         {{- if $root.Values.store.certSecretName }}
         - mountPath: /etc/certs
@@ -105,20 +109,22 @@ spec:
         {{- end }}
         {{- if $root.Values.store.livenessProbe }}
         livenessProbe:
-        {{ toYaml $root.Values.store.livenessProbe | nindent 8 }}
+        {{ toYaml $root.Values.store.livenessProbe | nindent 10 }}
         {{- end }}
         {{- if $root.Values.store.readinessProbe }}
         readinessProbe:
-        {{ toYaml $root.Values.store.readinessProbe | nindent 8 }}
+        {{ toYaml $root.Values.store.readinessProbe | nindent 10 }}
         {{- end }}
         resources:
-          {{ toYaml $root.Values.store.resources | nindent 10 }}
+        {{ toYaml $root.Values.store.resources | nindent 10 }}
       volumes:
-      - name: data
+      {{- if not $root.Values.store.statefulSet.enabled }}
+      - name: thanos-store-data
       {{- if $root.Values.store.dataVolume.backend }}
         {{ toYaml $root.Values.store.dataVolume.backend | nindent 8 }}
       {{- else }}
         emptyDir: {}
+      {{- end }}
       {{- end }}
       - name: config-volume
         secret:
@@ -148,6 +154,21 @@ spec:
       {{- with  $root.Values.store.serviceAccount }}
       serviceAccountName: "{{ . }}"
       {{- end }}
+  {{- if $root.Values.store.statefulSet.enabled }}
+  {{- with $root.Values.store.statefulSet }}
+  volumeClaimTemplates:
+  - metadata:
+      name: thanos-store-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .size }}
+      storageClassName: {{ .storageClassName }}
+      volumeMode: Filesystem
+  {{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -55,6 +55,11 @@ store:
   #    volumeName: ""
   #    volumeMode: ""
   # Extra labels for store pod template
+  # StatefulSet rather than Deployment
+  statefulSet:
+    enabled: false
+    size: 10G
+    storageClassName: default
   labels: {}
   #  cluster: example
   #


### PR DESCRIPTION
The chart didn't manage to use PVC with replica > 1.
StatefulSet permit to use dynamic allocation of storage resources
that persist after the restart/deletion/eviction of the pod.